### PR TITLE
write the input fastq_files.txt to output

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -25,9 +25,6 @@ sample_information = maybe_local(params.sample_information)
 sample_info = Channel.fromPath(sample_information)
 
 Channel.fromPath(fastq_list)
-    .into{ fastq_list1; fastq_list2; fastq_list3 }
-
-fastq_list1
     .splitText()
     .map { it.trim() }
     .map { maybe_local(it) }

--- a/main.nf
+++ b/main.nf
@@ -57,8 +57,6 @@ process copy_filelist {
     """
     cp ${fastq_file} fastq_list.csv
     """
-
-
 }
 
 process read_manifest {

--- a/main.nf
+++ b/main.nf
@@ -45,6 +45,22 @@ to_plot_quality = sample_map2
 
 // to_plot_quality.println { "Received: $it" }
 
+process copy_filelist {
+    input:
+        file(fastq_file) from Channel.fromPath(fastq_list)
+
+    output:
+        file("fastq_list.csv")
+
+    publishDir params.output, overwrite: true
+
+    """
+    cp ${fastq_file} fastq_list.csv
+    """
+
+
+}
+
 process read_manifest {
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -24,6 +24,9 @@ sample_information = maybe_local(params.sample_information)
 // TODO: use of 'maybe_local()' is untested with s3 objects
 sample_info = Channel.fromPath(sample_information)
 Channel.fromPath(fastq_list)
+    .into{ fastq_list1; fastq_list2; fastq_list3 }
+
+fastq_list1
     .splitText()
     .map { it.trim() }
     .map { maybe_local(it) }
@@ -47,7 +50,7 @@ to_plot_quality = sample_map2
 
 process copy_filelist {
     input:
-        file(fastq_file) from Channel.fromPath(fastq_list)
+        file(fastq_files) from fastq_list2
 
     output:
         file("fastq_list.csv")
@@ -55,7 +58,7 @@ process copy_filelist {
     publishDir params.output, overwrite: true
 
     """
-    cp ${fastq_file} fastq_list.csv
+    cp ${fastq_files} fastq_list.csv
     """
 }
 
@@ -63,7 +66,7 @@ process read_manifest {
 
     input:
         file(sample_info) from sample_info
-        file(fastq_files) from Channel.fromPath(fastq_list)
+        file(fastq_files) from fastq_list3
 
     output:
         file("batches.csv") into batches

--- a/main.nf
+++ b/main.nf
@@ -23,6 +23,7 @@ sample_information = maybe_local(params.sample_information)
 // and arrange into a sequence of (sampleid, I1, [I2], R1, R2)
 // TODO: use of 'maybe_local()' is untested with s3 objects
 sample_info = Channel.fromPath(sample_information)
+
 Channel.fromPath(fastq_list)
     .into{ fastq_list1; fastq_list2; fastq_list3 }
 
@@ -48,9 +49,11 @@ to_plot_quality = sample_map2
 
 // to_plot_quality.println { "Received: $it" }
 
+fastq_file_val = Channel.value(fastq_list)
+
 process copy_filelist {
     input:
-        file(fastq_files) from fastq_list2
+        file(fastq_files) from fastq_file_val
 
     output:
         file("fastq_list.csv")
@@ -66,7 +69,7 @@ process read_manifest {
 
     input:
         file(sample_info) from sample_info
-        file(fastq_files) from fastq_list3
+        file(fastq_files) from fastq_file_val
 
     output:
         file("batches.csv") into batches


### PR DESCRIPTION
Here's a try at #19. I haven't learned details about `Channel` yet, so useage may be unnecessary. Also would be interested in knowing if there's a more elegant method for moving a file than invoking `cp input output` as I've done here.