### PR TITLE
extend manifest KEEP_COLS to include NGS16S input metadata cols

### DIFF
--- a/bin/manifest.py
+++ b/bin/manifest.py
@@ -23,7 +23,9 @@ import re
 
 import openpyxl
 
-KEEPCOLS = {'sampleid', 'sample_name', 'project', 'batch', 'controls'}
+KEEPCOLS = {'sampleid', 'sample_name', 'project', 'batch', 'controls',
+            'label', 'barcode_id', 'run_number', 'blast_database',
+            'desc', 'other', 'quant', 'paired_ntc'}
 
 
 def read_manifest_excel(fname, keepcols=KEEPCOLS):


### PR DESCRIPTION
closes #23 

This is for convenience in providing data to the `NGS16S` classification pipeline. If needed columns are provided as input to `dada2-nf` via `sample_information.csv` and passed through to the pipeline output, the downstream pipeline can pick up `sample_information.csv` with minimal modifications.