### PR TITLE
Fix issue with zero-padding in sv names

### DIFF
--- a/bin/write_seqs.py
+++ b/bin/write_seqs.py
@@ -121,7 +121,7 @@ def main(arguments):
     # order by overall count, desc; include hash of seq to make sure
     # sorting of ties is stable
     svlist.sort(key=lambda r: (r[0], hash(r[2])), reverse=True)
-    padchars = math.ceil(math.log10(svlist[0][0] + 1))
+    padchars = math.ceil(math.log10(len(svlist) + 1))
 
     def svname(i, specimen=None):
         sv = 'sv-{:0{}}'.format(i, padchars)


### PR DESCRIPTION
Tested this fix using both the minimal test set and the NGS16S test set.

Minimal test set results:

> mmwohl@unicorn:/molmicro/working/molly/src/dada2-nf$ cat output-minimal/weights.csv
sv-01:m3n716-s502,sv-01:m3n716-s502,491
sv-02:m3n701-s502,sv-02:m3n701-s502,315
sv-03:m3n701-s502,sv-03:m3n701-s502,306
sv-04:m3n716-s502,sv-04:m3n716-s502,103
sv-05:m3n716-s502,sv-05:m3n716-s502,65
sv-06:m3n701-s502,sv-06:m3n701-s502,59
sv-07:m3n716-s502,sv-07:m3n716-s502,50
sv-08:m3n701-s502,sv-08:m3n701-s502,41
sv-09:m3n701-s502,sv-09:m3n701-s502,15
sv-10:m3n716-s502,sv-10:m3n716-s502,14
sv-11:m3n716-s502,sv-11:m3n716-s502,6

NGS16S test results:

> mmwohl@unicorn:/molmicro/working/molly/src/dada2-nf$ head output-single/weights.csv
sv-001:795-4,sv-001:795-4,196
sv-001:795-4,sv-001:795-6,121
sv-001:795-4,sv-001:879-9,49
sv-001:795-4,sv-001:795-3,22
sv-002:795-6,sv-002:795-6,148
sv-002:795-6,sv-002:879-9,140
sv-002:795-6,sv-002:795-4,64
sv-002:795-6,sv-002:795-3,25
sv-003:795-3,sv-003:795-3,149
sv-004:795-4,sv-004:795-4,54
mmwohl@unicorn:/molmicro/working/molly/src/dada2-nf$ tail output-single/weights.csv
sv-100:795-3,sv-100:795-3,3
sv-101:795-5,sv-101:795-5,3
sv-102:795-5,sv-102:795-5,3
sv-103:795-3,sv-103:795-3,3
sv-104:879-9,sv-104:879-9,3
sv-105:795-5,sv-105:795-5,2
sv-106:795-5,sv-106:795-5,2
sv-107:795-3,sv-107:795-3,2
sv-108:795-3,sv-108:795-3,2
sv-109:795-3,sv-109:795-3,2
