### PR TITLE
Update base r image used in Dockerfile to fix dependency issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-apt:bionic
+FROM rocker/r-ubuntu:20.04
 
 ARG DADA2_COMMIT
 ENV DADA2_COMMIT=$DADA2_COMMIT


### PR DESCRIPTION
Updating the base r image used in the Dockerfile gets past the dependency issue seen in #33