### PR TITLE
Add process to run get_unmerged

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - New downsample: [int] argument in params (GH38)
 - use dada2 1.18
+- output includes files containing unmerged reads
 
 ## 1.14
 

--- a/main.nf
+++ b/main.nf
@@ -307,7 +307,8 @@ process dada_get_unmerged {
     publishDir "${params.output}/dada/${sampleid}/", overwrite: true
 
     """
-    get_unmerged.R ${dada_rds}
+    get_unmerged.R ${dada_rds} \
+        --forward-seqs unmerged_F.fasta --reverse-seqs unmerged_R.fasta
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -261,6 +261,7 @@ process learn_errors {
     """
 }
 
+
 process dada_dereplicate {
 
     label 'med_cpu_mem'
@@ -275,6 +276,7 @@ process dada_dereplicate {
         file("seqtab.csv") into dada_seqtab
         file("counts.csv") into dada_counts
         file("overlaps.csv") into dada_overlaps
+        val sampleid into dada_dereplicate_samples
 
     publishDir "${params.output}/dada/${sampleid}/", overwrite: true
 
@@ -287,6 +289,26 @@ process dada_dereplicate {
         --seqtab seqtab.csv \
         --counts counts.csv \
         --overlaps overlaps.csv
+    """
+}
+
+
+process dada_get_unmerged {
+
+    label 'med_cpu_mem'
+
+    input:
+        val sampleid from dada_dereplicate_samples
+        file("dada_params.json") from maybe_local(params.dada_params)
+        each dada_rds from dada_data
+
+    output:
+        file("unmerged_*.fasta") into dada_unmerged
+
+    publishDir "${params.output}/dada/${sampleid}/", overwrite: true
+
+    """
+    get_unmerged.R ${dada_rds}
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -292,7 +292,6 @@ process dada_dereplicate {
     """
 }
 
-
 process dada_get_unmerged {
 
     label 'med_cpu_mem'
@@ -300,7 +299,7 @@ process dada_get_unmerged {
     input:
         val sampleid from dada_dereplicate_samples
         file("dada_params.json") from maybe_local(params.dada_params)
-        each dada_rds from dada_data
+        file dada_rds from dada_data
 
     output:
         file("unmerged_*.fasta") into dada_unmerged


### PR DESCRIPTION
- generates expected outputs, but maybe is being called redundantly

I was testing this using `params-ngs16s.json` as follows:

```sh
dhoogest@gattaca:/molmicro/working/dhoogest/src/dada2-nf$ ./nextflow run main.nf -params-file params-ngs16s.json
```

Pipeline runs successfully and generates expected output:

```sh
dhoogest@gattaca:/molmicro/working/dhoogest/src/dada2-nf$ ls -lat output-single/dada/*/unmerged*
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/879-9/unmerged_R.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/37/1f9a4d1bbf0dfa5b25237958ec320a/unmerged_R.fasta
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/879-9/unmerged_F.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/37/1f9a4d1bbf0dfa5b25237958ec320a/unmerged_F.fasta
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/795-6/unmerged_F.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/3b/d382b57cae8d4304e28f52590821ab/unmerged_F.fasta
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/795-6/unmerged_R.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/3b/d382b57cae8d4304e28f52590821ab/unmerged_R.fasta
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/795-5/unmerged_R.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/0c/7ad3227ce45f4cd997dd067af3d036/unmerged_R.fasta
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/795-5/unmerged_F.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/0c/7ad3227ce45f4cd997dd067af3d036/unmerged_F.fasta
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/795-3/unmerged_R.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/c1/37fb621e0d68645bf1981a29b9579b/unmerged_R.fasta
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/795-3/unmerged_F.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/c1/37fb621e0d68645bf1981a29b9579b/unmerged_F.fasta
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/1029-38/unmerged_F.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/a0/fc0fcb288f9fe2edbd216fc63b6700/unmerged_F.fasta
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/1029-38/unmerged_R.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/a0/fc0fcb288f9fe2edbd216fc63b6700/unmerged_R.fasta
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/795-4/unmerged_F.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/4a/4fbf013c09a4249ab0f6a8e0f52129/unmerged_F.fasta
lrwxrwxrwx 1 dhoogest domain^users 106 Feb 23 10:49 output-single/dada/795-4/unmerged_R.fasta -> /mnt/disk15/molmicro/working/dhoogest/src/dada2-nf/work/4a/4fbf013c09a4249ab0f6a8e0f52129/unmerged_R.fasta
```

However, the counter for the process in the nextflow 'steps' (not sure what these are called) indicates 36, where I think there should only be 12 (6 .rds inputs, F/R each). Likely something I don't understand fully about specifying nextflow inputs/outputs - @nhoffman @crosenth lemme know if you have suggestions:

```sh
dhoogest@gattaca:/molmicro/working/dhoogest/src/dada2-nf$ ./nextflow run main.nf -params-file params-ngs16s.json
N E X T F L O W  ~  version 20.10.0
Launching `main.nf` [soggy_noether] - revision: 714ef7e750
executor >  local (73)
[04/0a83ac] process > copy_filelist          [100%] 1 of 1 ✔
[79/8e6e5d] process > read_manifest (1)      [100%] 1 of 1 ✔
[42/953437] process > plot_quality (4)       [100%] 6 of 6 ✔
[51/76ba1a] process > barcodecop_single (5)  [100%] 6 of 6 ✔
[d4/45076f] process > bcop_counts_concat     [100%] 1 of 1 ✔
[b4/5103a1] process > filter_and_trim (1)    [100%] 6 of 6 ✔
[9e/8ffbc9] process > learn_errors (1)       [100%] 3 of 3 ✔
[a8/efe171] process > dada_dereplicate (5)   [100%] 6 of 6 ✔
[37/1f9a4d] process > dada_get_unmerged (36) [100%] 36 of 36 ✔
[c0/2365da] process > combined_overlaps      [100%] 1 of 1 ✔
[c8/297da3] process > dada_counts_concat     [100%] 1 of 1 ✔
[57/1adccd] process > write_seqs             [100%] 1 of 1 ✔
[bc/e743d3] process > cmsearch               [100%] 1 of 1 ✔
[27/a22588] process > filter_svs             [100%] 1 of 1 ✔
[99/8378aa] process > join_counts            [100%] 1 of 1 ✔
[51/e15258] process > save_params            [100%] 1 of 1 ✔
Completed at: 23-Feb-2022 10:49:31
Duration    : 1m 37s
CPU hours   : 0.2
Succeeded   : 73
```