### PR TITLE
handle scenario where there are no merged seqs for a sample

### DIFF
--- a/bin/get_unmerged.R
+++ b/bin/get_unmerged.R
@@ -21,6 +21,8 @@ get_unmerged <- function(obj, orientation){
   if(!is.null(merged_idx)){
     ## return a vector of fasta records
     gettextf('>%s%s:%s\n%s', ori, seqnames[-merged_idx], abundance[-merged_idx], denoised[-merged_idx])
+  } else {
+    ''
   }
 }
 

--- a/bin/get_unmerged.R
+++ b/bin/get_unmerged.R
@@ -18,8 +18,10 @@ get_unmerged <- function(obj, orientation){
   padchars <- ceiling(log10(length(denoised) + 1))
   seqnames <- gettextf(paste0('%0', padchars, 'i'), seq(length(denoised)))
 
-  ## return a vector of fasta records
-  gettextf('>%s%s:%s\n%s', ori, seqnames[-merged_idx], abundance[-merged_idx], denoised[-merged_idx])
+  if(!is.null(merged_idx)){
+    ## return a vector of fasta records
+    gettextf('>%s%s:%s\n%s', ori, seqnames[-merged_idx], abundance[-merged_idx], denoised[-merged_idx])
+  }
 }
 
 main <- function(arguments){


### PR DESCRIPTION
- get_unmerged.R currently fails when encountering a sample forw which
the `[merged]` table is `NULL`. This MR simply wraps in a conditional
the step where merged_idx is required to be non-null