### PR TITLE
Force dsl1 from config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,9 @@
 // these values supersede params in the profile and are themselves
 // superseded by contents of -params-file or command line args
+
+// force dsl 1 until main.nf is updated
+nextflow.enable.dsl=1
+
 params {
     image = 'dada2-nf:v1.15'
     // versions > 14 hosted on docker hub


### PR DESCRIPTION
With versions of nextflow >= 22.03, DSL2 is the default syntax (see [here](https://www.nextflow.io/docs/edge/dsl2.html)). This creates problems for the current `main.nf`, specifically `.into()`:


```sh
nextflow run https://github.com/nhoffman/dada2-nf -revision master -latest -profile singularity -params-file configs/params.json
NOTE: Nextflow is not tested with Java 1.8.0_312 -- It's recommended the use of version 11 up to 18


N E X T F L O W ~ version 22.04.0
Pulling nhoffman/dada2-nf ...
Already-up-to-date
WARN: It appears you have never run this project before -- Option `-resume` is ignored
Launching `[https://github.com/nhoffman/dada2-nf`](https://github.com/nhoffman/dada2-nf%60) [adoring_banach] DSL2 - revision: ee1c4bf2e1 [master]
Operator `into` has been deprecated -- it's not available in DSL2 syntax


-- Check script '/mnt/home/dhoogest/.nextflow/assets/nhoffman/dada2-nf/main.nf' at line: 27 or see '.nextflow.log' file for more details
```

Modification of the top level nextflow config here forces use of DSL=1, which I think will be needed until such time as we update the `main.nf` script. 

Downloading nextflow-latest in a temp dir then running tests should reproduce the error, and confirm the fix here once branch is checked out.

/cc @mwohl 