### PR TITLE
WIP: Handle null seqtab in get_chim_dropped.R

### DIFF
--- a/bin/dada2_plot_quality.R
+++ b/bin/dada2_plot_quality.R
@@ -63,8 +63,7 @@ main <- function(arguments){
   }
 
   height <- 480
-  ## the input fastq.gz is already unzipped when passed from nextflow
-  if(file.info(args$r1)$size == 0){
+  if(gzip_size(args$r1) == 0){
     png(args$outfile, width=height * 2, height=height)
     plot.new()
     title(gettextf('%s is empty', args$specimen))

--- a/bin/dada2_plot_quality.R
+++ b/bin/dada2_plot_quality.R
@@ -63,7 +63,8 @@ main <- function(arguments){
   }
 
   height <- 480
-  if(gzip_size(args$r1) == 0){
+  ## the input fastq.gz is already unzipped when passed from nextflow
+  if(file.info(args$r1)$size == 0){
     png(args$outfile, width=height * 2, height=height)
     plot.new()
     title(gettextf('%s is empty', args$specimen))

--- a/bin/dada2_plot_quality.R
+++ b/bin/dada2_plot_quality.R
@@ -62,7 +62,7 @@ main <- function(arguments){
     r_trunc <- params$truncLen[2]
   }
 
-  height = 480
+  height <- 480
   if(gzip_size(args$r1) == 0){
     png(args$outfile, width=height * 2, height=height)
     plot.new()

--- a/bin/dada2_plot_quality.R
+++ b/bin/dada2_plot_quality.R
@@ -26,7 +26,7 @@ gzip_size <- function(fname){
   ## stdout looks something like
   ## [1] "         compressed        uncompressed  ratio uncompressed_name"
   ## [2] "                 53                   0   0.0% filename
-  out <- system2('gunzip', c('-l', fname), stdout=TRUE)
+  out <- system2('gunzip', c('-l', fname), c('--stdout'), stdout=TRUE)
   as.integer(unlist(strsplit(out[2], "\\s+"))[3])
 }
 

--- a/bin/dada2_plot_quality.R
+++ b/bin/dada2_plot_quality.R
@@ -26,7 +26,7 @@ gzip_size <- function(fname){
   ## stdout looks something like
   ## [1] "         compressed        uncompressed  ratio uncompressed_name"
   ## [2] "                 53                   0   0.0% filename
-  out <- system2('gunzip', c('-l', fname), c('--stdout'), stdout=TRUE)
+  out <- system2('gunzip', c('-l', fname), stdout=TRUE)
   as.integer(unlist(strsplit(out[2], "\\s+"))[3])
 }
 

--- a/bin/get_dropped_chim.R
+++ b/bin/get_dropped_chim.R
@@ -2,9 +2,10 @@
 
 suppressPackageStartupMessages(library(argparse, quietly = TRUE))
 suppressPackageStartupMessages(library(tidyr, quietly = TRUE))
+suppressPackageStartupMessages(library(tibble, quietly = TRUE))
 suppressPackageStartupMessages(library(readr, quietly = TRUE))
 suppressPackageStartupMessages(library(dplyr, quietly = TRUE))
-n
+
 main <- function(arguments){
   parser <- ArgumentParser(
       description="Write forward and reverse unmerged denoised, dereplicated reads")
@@ -25,8 +26,7 @@ main <- function(arguments){
     ## detect and output the 'dropped' seqs and their weights
     tab <- seqtab %>% anti_join(seqtab.nochim, by=c('Var2')) %>%
       arrange(-Freq) %>% rename(sequence=Var2) %>%
-      rename(weight=Freq) %>% select(weight, sequence) %>%
-
+      rename(weight=Freq) %>% select(weight, sequence)
   } else {
     tab <- tibble(weight=numeric(),sequence=character())
   }

--- a/bin/get_dropped_chim.R
+++ b/bin/get_dropped_chim.R
@@ -31,5 +31,6 @@ main <- function(arguments){
     tab <- tibble(weight=numeric(),sequence=character())
   }
   tab %>% write_csv(args$outfile)
+}
 
 main(commandArgs(trailingOnly=TRUE))

--- a/bin/get_dropped_chim.R
+++ b/bin/get_dropped_chim.R
@@ -16,16 +16,20 @@ main <- function(arguments){
   args <- parser$parse_args(arguments)
 
   obj <- readRDS(args$rdata)
-  seqtab <- as.data.frame(as.table(obj$seqtab))
-  seqtab.nochim <- as.data.frame(as.table(obj$seqtab.nochim))
+  if (!is.null(obj$seqtab) && !is.null(obj$seqtab.nochim)) {
+    seqtab <- as.data.frame(as.table(obj$seqtab))
+    seqtab.nochim <- as.data.frame(as.table(obj$seqtab.nochim))
 
-  ## use of anti_join returns records in seqtab which are not
-  ## present in the filtered seqtab.nochim. In other words,
-  ## detect and output the 'dropped' seqs and their weights
-  seqtab %>% anti_join(seqtab.nochim, by=c('Var2')) %>%
-        arrange(-Freq) %>% rename(sequence=Var2) %>%
-        rename(weight=Freq) %>% select(weight, sequence) %>%
-        write_csv(args$outfile)
-}
+    ## use of anti_join returns records in seqtab which are not
+    ## present in the filtered seqtab.nochim. In other words,
+    ## detect and output the 'dropped' seqs and their weights
+    tab <- seqtab %>% anti_join(seqtab.nochim, by=c('Var2')) %>%
+      arrange(-Freq) %>% rename(sequence=Var2) %>%
+      rename(weight=Freq) %>% select(weight, sequence) %>%
+
+  } else {
+    tab <- tibble(weight=numeric(),sequence=character())
+  }
+  tab %>% write_csv(args$outfile)
 
 main(commandArgs(trailingOnly=TRUE))


### PR DESCRIPTION
@nhoffman @mwohl Steve wanted a uniNGS experiment run which has a bunch of non-template controls in checkerboard arrangement to isolate amplifications. The low weight samples in the batch pointed out an omission in the newly added get_chim_dropped.R, in that in the event that no sequences survive filtering (dada.rds `seqtab` is NULL) the script errors out. I've added a conditional here to write a headers-only file in the empty scenario and am testing a bit more to see if there are downstream implications. 