### PR TITLE
modify ungs dada2 params to incorporate ngs16s specific preferences

### DIFF
--- a/data/dada_params_ungs.json
+++ b/data/dada_params_ungs.json
@@ -1,13 +1,22 @@
 {
   "fastqPairedFilter": {
     "trimLeft": 15,
-    "trimRight": 15
+    "trimRight": 15,
+    "maxN": 0,
+    "maxEE": 1,
+    "truncQ": 2
   },
   "dada": {
     "selfConsist": true,
-    "BAND_SIZE": 16
+    "BAND_SIZE": 4,
+    "OMEGA_A": 1e-100,
+    "OMEGA_C": 1e-40
   },
   "mergePairs": {
-    "maxMismatch": 1
+    "maxMismatch": 0
+  },
+  "removeBimeraDenovo": {
+    "minFoldParentOverAbundance": 4,
+    "method": "per-sample"
   }
 }


### PR DESCRIPTION
@nhoffman this PR updates the dada2 settings for ungs to include parameters which are explicit in https://github.com/nhoffman/dada2-nf/blob/master/data/dada_params_ngs16s.json. Most of these were set in response to behavior of SV inference from the NGS16S history (see [here](https://gitlab.labmed.uw.edu/molmicro/NGS16S/-/issues/78#note_12289)), and it seems favorable to unify in advance of an eventual method transition.