### PR TITLE
version bump docker base to rocker/r-ubuntu:22.04, install gridextra explicitly

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: print tag name
-        run: echo ghcr.io/${{ env.GITHUB_REPOSITORY }}:${{ env.GITHUB_REF_NAME }}
+        run: echo ghcr.io/${{ github.respository }}:${{ github.ref_name }}
 
       - name: Build and push on git tag event
         if: env.GITHUB_REF_TYPE == 'tag'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,12 @@
 name: Build and push docker image
 
-on: push
-  # push:
-  #   branches:
-  #     - master
-  #     - '[0-9]+-*'
-  #   tags: [ '*.*.*' ]
+on:
+  push:
+    branches:
+      - master
+      - '[0-9]+-*'
+    tags:
+      - '[0-9]+.[0-9]+(.[0-9]+)?'
 
 jobs:
   push_to_registry:
@@ -24,9 +25,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: print tag name
-        run: echo ghcr.io/${{ github.respository }}:${{ github.ref_name }} ${{ github.ref_type }}
-
       - name: Build and push on git tag event
         if: github.ref_type == 'tag'
         uses: docker/build-push-action@v3
@@ -39,7 +37,7 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 
       - name: Build and push on git push to branch
-        # if: github.ref_type == 'branch'
+        if: github.ref_type == 'branch'
         uses: docker/build-push-action@v3
         with:
           build-args: DADA2_COMMIT=v1.18

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build and push on git tag event
         if: github.GITHUB_REF_TYPE == 'tag'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           build-args: DADA2_COMMIT=v1.18
           context: "{{defaultContext}}:docker"
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build and push on git push to branch
         if: github.GITHUB_REF_TYPE == 'branch'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           build-args: DADA2_COMMIT=v1.18
           context: "{{defaultContext}}:docker"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: print tag name
+        run: echo ghcr.io/${{ GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
+
       - name: Build and push on git tag event
         if: github.GITHUB_REF_TYPE == 'tag'
         uses: docker/build-push-action@v3
@@ -32,8 +35,8 @@ jobs:
           context: "{{defaultContext}}:docker"
           push: true
           tags: |
-            ghcr.io/nhoffman/dada2-nf:latest
-            ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
+            ghcr.io/${{ GITHUB_REPOSITORY }}:latest
+            ghcr.io/${{ GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
 
       - name: Build and push on git push to branch
         # if: github.GITHUB_REF_TYPE == 'branch'
@@ -43,5 +46,5 @@ jobs:
           context: "{{defaultContext}}:docker"
           push: true
           tags: |
-            ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
+            ghcr.io/${{ GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ on:
       - '[0-9]+.[0-9]+(.[0-9]+)?'
 
 jobs:
-  push_to_registry:
+  docker_build_and_push:
     runs-on: ubuntu-latest
     steps:
       - name: print all environment variables
@@ -45,4 +45,24 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+    - run: |
+        cd /usr/local/bin/
+        wget -qO - https://get.nextflow.io | bash
+    - run: nextflow -quiet run main.nf -params-file params-minimal.json -without-docker
+    - run: nextflow -quiet run main.nf -params-file params-its.json -without-docker
+    - run: nextflow -quiet run main.nf -params-file params-noindex.json -without-docker
+    - run: nextflow -quiet run main.nf -params-file params-single-cmsearch.json -without-docker
+    - run: nextflow -quiet run main.nf -params-file params-single-vsearch.json -without-docker
+    - run: cmp --silent output-cmsearch/counts.csv output-vsearch/counts.csv
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,7 +36,7 @@ jobs:
             ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
 
       - name: Build and push on git push to branch
-        if: github.GITHUB_REF_TYPE == 'branch'
+        # if: github.GITHUB_REF_TYPE == 'branch'
         uses: docker/build-push-action@v3
         with:
           build-args: DADA2_COMMIT=v1.18

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,9 @@ jobs:
   push_to_registry:
     runs-on: ubuntu-latest
     steps:
+      - name: print all environment variables
+        run: env
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: print tag name
-        run: echo ghcr.io/${{ GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
+        run: echo ghcr.io/${{ github.GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
 
       - name: Build and push on git tag event
         if: github.GITHUB_REF_TYPE == 'tag'
@@ -35,8 +35,8 @@ jobs:
           context: "{{defaultContext}}:docker"
           push: true
           tags: |
-            ghcr.io/${{ GITHUB_REPOSITORY }}:latest
-            ghcr.io/${{ GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
+            ghcr.io/${{ github.GITHUB_REPOSITORY }}:latest
+            ghcr.io/${{ github.GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
 
       - name: Build and push on git push to branch
         # if: github.GITHUB_REF_TYPE == 'branch'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,11 @@
 name: Build and push docker image
 
-on:
-  push:
-    branches:
-      - master
-      - '[0-9]+-*'
-    tags: [ '*.*.*' ]
+on: push
+  # push:
+  #   branches:
+  #     - master
+  #     - '[0-9]+-*'
+  #   tags: [ '*.*.*' ]
 
 jobs:
   push_to_registry:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,26 +25,26 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: print tag name
-        run: echo ghcr.io/${{ github.respository }}:${{ github.ref_name }}
+        run: echo ghcr.io/${{ github.respository }}:${{ github.ref_name }} ${{ github.ref_type }}
 
       - name: Build and push on git tag event
-        if: env.GITHUB_REF_TYPE == 'tag'
+        if: github.ref_type == 'tag'
         uses: docker/build-push-action@v3
         with:
           build-args: DADA2_COMMIT=v1.18
           context: "{{defaultContext}}:docker"
           push: true
           tags: |
-            ghcr.io/${{ env.GITHUB_REPOSITORY }}:latest
-            ghcr.io/${{ env.GITHUB_REPOSITORY }}:${{ env.GITHUB_REF_NAME }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 
       - name: Build and push on git push to branch
-        # if: env.GITHUB_REF_TYPE == 'branch'
+        # if: github.ref_type == 'branch'
         uses: docker/build-push-action@v3
         with:
           build-args: DADA2_COMMIT=v1.18
           context: "{{defaultContext}}:docker"
           push: true
           tags: |
-            ghcr.io/${{ env.GITHUB_REPOSITORY }}:${{ env.GITHUB_REF_NAME }}
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,19 +11,6 @@ jobs:
   push_to_registry:
     runs-on: ubuntu-latest
     steps:
-      - name: set docker tags on git tag event
-        if: github.GITHUB_REF_TYPE == 'tag'
-        env:
-          TAGS: |
-            ghcr.io/nhoffman/dada2-nf:latest
-            ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
-
-      - name: set docker tags on push to branch
-        if: github.GITHUB_REF_TYPE == 'branch'
-        env:
-          TAGS: |
-            ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -34,10 +21,24 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push on git tag event
+        if: github.GITHUB_REF_TYPE == 'tag'
         uses: docker/build-push-action@v2
         with:
           build-args: DADA2_COMMIT=v1.18
           context: "{{defaultContext}}:docker"
           push: true
-          tags: ${{ env.TAGS }}
+          tags: |
+            ghcr.io/nhoffman/dada2-nf:latest
+            ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
+
+      - name: Build and push on git push to branch
+        if: github.GITHUB_REF_TYPE == 'branch'
+        uses: docker/build-push-action@v2
+        with:
+          build-args: DADA2_COMMIT=v1.18
+          context: "{{defaultContext}}:docker"
+          push: true
+          tags: |
+            ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
+

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,26 +25,26 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: print tag name
-        run: echo ghcr.io/${{ github.GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
+        run: echo ghcr.io/${{ env.GITHUB_REPOSITORY }}:${{ env.GITHUB_REF_NAME }}
 
       - name: Build and push on git tag event
-        if: github.GITHUB_REF_TYPE == 'tag'
+        if: env.GITHUB_REF_TYPE == 'tag'
         uses: docker/build-push-action@v3
         with:
           build-args: DADA2_COMMIT=v1.18
           context: "{{defaultContext}}:docker"
           push: true
           tags: |
-            ghcr.io/${{ github.GITHUB_REPOSITORY }}:latest
-            ghcr.io/${{ github.GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
+            ghcr.io/${{ env.GITHUB_REPOSITORY }}:latest
+            ghcr.io/${{ env.GITHUB_REPOSITORY }}:${{ env.GITHUB_REF_NAME }}
 
       - name: Build and push on git push to branch
-        # if: github.GITHUB_REF_TYPE == 'branch'
+        # if: env.GITHUB_REF_TYPE == 'branch'
         uses: docker/build-push-action@v3
         with:
           build-args: DADA2_COMMIT=v1.18
           context: "{{defaultContext}}:docker"
           push: true
           tags: |
-            ghcr.io/${{ github.GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
+            ghcr.io/${{ env.GITHUB_REPOSITORY }}:${{ env.GITHUB_REF_NAME }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,29 +10,31 @@ on: push
 jobs:
   push_to_registry:
     runs-on: ubuntu-latest
-    if: github.GITHUB_REF_TYPE == 'tag'
-    env:
-      TAGS: |
-        ghcr.io/nhoffman/dada2-nf:latest
-        ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
-    if: github.GITHUB_REF_TYPE == 'branch'
-    env:
-      TAGS: |
-        ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
-
     steps:
-      -
-        name: Set up Docker Buildx
+      - name: set docker tags on git tag event
+        if: github.GITHUB_REF_TYPE == 'tag'
+        env:
+          TAGS: |
+            ghcr.io/nhoffman/dada2-nf:latest
+            ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
+
+      - name: set docker tags on push to branch
+        if: github.GITHUB_REF_TYPE == 'branch'
+        env:
+          TAGS: |
+            ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Login to GitHub Container Registry
+
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v2
         with:
           build-args: DADA2_COMMIT=v1.18

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,15 +2,25 @@ name: Build and push docker image
 
 on:
   push:
+    branches:
+      - master
+      - '[0-9]+-*'
     tags: [ '*.*.*' ]
 
 jobs:
   push_to_registry:
     runs-on: ubuntu-latest
+    if: github.GITHUB_REF_TYPE == 'tag'
+    env:
+      TAGS: |
+        ghcr.io/nhoffman/dada2-nf:latest
+        ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
+    if: github.GITHUB_REF_TYPE == 'branch'
+    env:
+      TAGS: |
+        ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
+
     steps:
-      -
-        name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -28,6 +38,4 @@ jobs:
           build-args: DADA2_COMMIT=v1.18
           context: "{{defaultContext}}:docker"
           push: true
-          tags: |
-            ghcr.io/nhoffman/dada2-nf:latest
-            ghcr.io/nhoffman/dada2-nf:${{ env.RELEASE_VERSION }}
+          tags: ${{ env.TAGS }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,6 +47,7 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 
   test:
+    needs: docker_build_and_push
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,5 +46,5 @@ jobs:
           context: "{{defaultContext}}:docker"
           push: true
           tags: |
-            ghcr.io/${{ GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
+            ghcr.io/${{ github.GITHUB_REPOSITORY }}:${{ github.GITHUB_REF_NAME }}
 

--- a/.github/workflows/test_runs.yml
+++ b/.github/workflows/test_runs.yml
@@ -2,15 +2,19 @@ name: Run dada2-nf test runs
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    branches:
+      - foo
+  #     - master
+  #     - '[0-9]+-*'
+  #   tags: [ '*.*.*' ]
+  # pull_request:
+  #   branches: [ master ]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/nhoffman/dada2-nf:latest
+      image: ghcr.io/nhoffman/dada2-nf:${{ github.GITHUB_REF_NAME }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ubuntu:20.04
+FROM rocker/r-ubuntu:22.04
 
 ARG DADA2_COMMIT
 ENV DADA2_COMMIT=$DADA2_COMMIT
@@ -13,6 +13,7 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     r-cran-dplyr \
     r-cran-lattice \
     r-cran-latticeextra \
+    r-cran-gridextra \
     r-cran-r.utils \
     r-cran-readr \
     r-cran-rmarkdown \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,37 +1,37 @@
 FROM rocker/r-ubuntu:22.04
 
-ARG DADA2_COMMIT
-ENV DADA2_COMMIT=$DADA2_COMMIT
+# ARG DADA2_COMMIT
+# ENV DADA2_COMMIT=$DADA2_COMMIT
 
-# https://ethicalhackx.com/speed-apt-get-update-parallel-downloads/
-ADD 99parallel /etc/apt/apt.conf.d/99parallel
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
-    python3-pip \
-    r-cran-ape \
-    r-cran-biocmanager \
-    r-cran-devtools \
-    r-cran-dplyr \
-    r-cran-lattice \
-    r-cran-latticeextra \
-    r-cran-gridextra \
-    r-cran-r.utils \
-    r-cran-readr \
-    r-cran-rmarkdown \
-    r-cran-tidyr \
-    libcurl4-openssl-dev \
-    libxml2 \
-    libxml2-dev
+# # https://ethicalhackx.com/speed-apt-get-update-parallel-downloads/
+# ADD 99parallel /etc/apt/apt.conf.d/99parallel
+# RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
+#     python3-pip \
+#     r-cran-ape \
+#     r-cran-biocmanager \
+#     r-cran-devtools \
+#     r-cran-dplyr \
+#     r-cran-lattice \
+#     r-cran-latticeextra \
+#     r-cran-gridextra \
+#     r-cran-r.utils \
+#     r-cran-readr \
+#     r-cran-rmarkdown \
+#     r-cran-tidyr \
+#     libcurl4-openssl-dev \
+#     libxml2 \
+#     libxml2-dev
 
-ADD requirements.txt /tmp/
-RUN pip3 install -r /tmp/requirements.txt
+# ADD requirements.txt /tmp/
+# RUN pip3 install -r /tmp/requirements.txt
 
-ADD install_infernal_and_easel.sh /tmp/
-RUN /tmp/install_infernal_and_easel.sh
+# ADD install_infernal_and_easel.sh /tmp/
+# RUN /tmp/install_infernal_and_easel.sh
 
-ADD install_vsearch.sh /tmp/
-RUN /tmp/install_vsearch.sh 2.21.1
+# ADD install_vsearch.sh /tmp/
+# RUN /tmp/install_vsearch.sh 2.21.1
 
-ADD install-dada2.R /tmp/
-RUN Rscript /tmp/install-dada2.R
-RUN mkdir -p /app /fh /mnt /run/shm
+# ADD install-dada2.R /tmp/
+# RUN Rscript /tmp/install-dada2.R
+# RUN mkdir -p /app /fh /mnt /run/shm
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,37 +1,37 @@
 FROM rocker/r-ubuntu:22.04
 
-# ARG DADA2_COMMIT
-# ENV DADA2_COMMIT=$DADA2_COMMIT
+ARG DADA2_COMMIT
+ENV DADA2_COMMIT=$DADA2_COMMIT
 
-# # https://ethicalhackx.com/speed-apt-get-update-parallel-downloads/
-# ADD 99parallel /etc/apt/apt.conf.d/99parallel
-# RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
-#     python3-pip \
-#     r-cran-ape \
-#     r-cran-biocmanager \
-#     r-cran-devtools \
-#     r-cran-dplyr \
-#     r-cran-lattice \
-#     r-cran-latticeextra \
-#     r-cran-gridextra \
-#     r-cran-r.utils \
-#     r-cran-readr \
-#     r-cran-rmarkdown \
-#     r-cran-tidyr \
-#     libcurl4-openssl-dev \
-#     libxml2 \
-#     libxml2-dev
+# https://ethicalhackx.com/speed-apt-get-update-parallel-downloads/
+ADD 99parallel /etc/apt/apt.conf.d/99parallel
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
+    python3-pip \
+    r-cran-ape \
+    r-cran-biocmanager \
+    r-cran-devtools \
+    r-cran-dplyr \
+    r-cran-lattice \
+    r-cran-latticeextra \
+    r-cran-gridextra \
+    r-cran-r.utils \
+    r-cran-readr \
+    r-cran-rmarkdown \
+    r-cran-tidyr \
+    libcurl4-openssl-dev \
+    libxml2 \
+    libxml2-dev
 
-# ADD requirements.txt /tmp/
-# RUN pip3 install -r /tmp/requirements.txt
+ADD requirements.txt /tmp/
+RUN pip3 install -r /tmp/requirements.txt
 
-# ADD install_infernal_and_easel.sh /tmp/
-# RUN /tmp/install_infernal_and_easel.sh
+ADD install_infernal_and_easel.sh /tmp/
+RUN /tmp/install_infernal_and_easel.sh
 
-# ADD install_vsearch.sh /tmp/
-# RUN /tmp/install_vsearch.sh 2.21.1
+ADD install_vsearch.sh /tmp/
+RUN /tmp/install_vsearch.sh 2.21.1
 
-# ADD install-dada2.R /tmp/
-# RUN Rscript /tmp/install-dada2.R
-# RUN mkdir -p /app /fh /mnt /run/shm
+ADD install-dada2.R /tmp/
+RUN Rscript /tmp/install-dada2.R
+RUN mkdir -p /app /fh /mnt /run/shm
 

--- a/docker/install-dada2.R
+++ b/docker/install-dada2.R
@@ -16,12 +16,15 @@ install.packages(
     Ncpus=ncores,
     clean=TRUE)
 
-devtools::install_github("benjjneb/dada2", ref=dada2_commit)
+devtools::install_github(
+    "benjjneb/dada2",
+    ref=dada2_commit,
+    threads=ncores)
 
 bioc_packages <- c(
     "qrqc",
     "phyloseq"
 )
 
-BiocManager::install(bioc_packages)
+BiocManager::install(bioc_packages, Ncpus=ncores)
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,9 +5,9 @@
 nextflow.enable.dsl=1
 
 params {
-    image = 'dada2-nf:v1.15'
-    // versions > 14 hosted on docker hub
-    docker_container = "nghoffman/$params.image"
+    image = 'dada2-nf:latest'
+    // Docker image is hosted on github
+    docker_container = "ghcr.io/nhoffman/$params.image"
     // https://cloud.sylabs.io/library/nhoffman/dada2-nf/dada2-nf
     singularity_container = "library://nhoffman/dada2-nf/$params.image"
     min_reads = 1

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,6 +4,8 @@
 // force dsl 1 until main.nf is updated
 nextflow.enable.dsl=1
 
+// these can be overridden using command line args like
+// --image dada2-nf:17.1
 params {
     image = 'dada2-nf:latest'
     // Docker image is hosted on github


### PR DESCRIPTION
This restored functional build of dada2 with passing tests for me locally, although I didn't get to the bottom of what  is wrong with the 20.04 base. 